### PR TITLE
chore: set up pnpm workspace and base tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "js_sourceit",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "pnpm@10.11.0",
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'packages/*'
+  - 'apps/*'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
## Summary
- add root package.json with pnpm workspaces
- define pnpm-workspace.yaml for packages and apps
- share TypeScript compiler options via tsconfig.base.json

## Testing
- `pnpm run test` (fails: Missing script: test)


------
https://chatgpt.com/codex/tasks/task_e_68aca49b5008832fbc012b3239d1f053